### PR TITLE
Ab/hashing

### DIFF
--- a/src/main/java/com/palantir/ri/ResourceIdentifier.java
+++ b/src/main/java/com/palantir/ri/ResourceIdentifier.java
@@ -66,15 +66,15 @@ public final class ResourceIdentifier {
     private final int locatorIndex;
 
     private ResourceIdentifier(String service, String instance, String type, String locator) {
-        String safeInstnace = instance == null ? "" : instance;
+        String safeInstance = instance == null ? "" : instance;
         resourceIdentifier = RID_CLASS + SEPARATOR
                 + service + SEPARATOR
-                + safeInstnace + SEPARATOR
+                + safeInstance + SEPARATOR
                 + type + SEPARATOR
                 + locator;
 
         serviceIndex = RID_CLASS.length() + SEPARATOR.length() + service.length();
-        instanceIndex = serviceIndex + SEPARATOR.length() + safeInstnace.length();
+        instanceIndex = serviceIndex + SEPARATOR.length() + safeInstance.length();
         typeIndex = instanceIndex + SEPARATOR.length() + type.length();
         locatorIndex = typeIndex + SEPARATOR.length() + locator.length();
 
@@ -158,10 +158,7 @@ public final class ResourceIdentifier {
             return false;
         }
         ResourceIdentifier other = (ResourceIdentifier) obj;
-        return Objects.equals(getService(), other.getService())
-                && Objects.equals(getInstance(), other.getInstance())
-                && Objects.equals(getType(), other.getType())
-                && Objects.equals(getLocator(), other.getLocator());
+        return Objects.equals(resourceIdentifier, other.resourceIdentifier);
     }
 
     /**

--- a/src/main/java/com/palantir/ri/ResourceIdentifier.java
+++ b/src/main/java/com/palantir/ri/ResourceIdentifier.java
@@ -134,7 +134,7 @@ public final class ResourceIdentifier {
      */
     @Override
     public int hashCode() {
-        return Objects.hash(service, instance, type, locator);
+        return locator.hashCode();
     }
 
     /**

--- a/src/main/java/com/palantir/ri/ResourceIdentifier.java
+++ b/src/main/java/com/palantir/ri/ResourceIdentifier.java
@@ -63,12 +63,14 @@ public final class ResourceIdentifier {
     private final String instance;
     private final String type;
     private final String locator;
+    private final String resourceIdentifier;
 
     private ResourceIdentifier(String service, String instance, String type, String locator) {
         this.service = service;
         this.instance = instance == null ? "" : instance;
         this.type = type;
         this.locator = locator;
+        resourceIdentifier = toString();
     }
 
     /**
@@ -134,7 +136,7 @@ public final class ResourceIdentifier {
      */
     @Override
     public int hashCode() {
-        return locator.hashCode();
+        return resourceIdentifier.hashCode();
     }
 
     /**

--- a/src/main/java/com/palantir/ri/ResourceIdentifier.java
+++ b/src/main/java/com/palantir/ri/ResourceIdentifier.java
@@ -18,6 +18,7 @@ package com.palantir.ri;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import java.nio.CharBuffer;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -77,7 +78,6 @@ public final class ResourceIdentifier {
         instanceIndex = serviceIndex + SEPARATOR.length() + safeInstance.length();
         typeIndex = instanceIndex + SEPARATOR.length() + type.length();
         locatorIndex = typeIndex + SEPARATOR.length() + locator.length();
-
     }
 
     /**
@@ -113,6 +113,7 @@ public final class ResourceIdentifier {
      * @return the locator component from this identifier
      */
     public String getLocator() {
+        CharBuffer.wrap(resourceIdentifier);
         return resourceIdentifier.substring(typeIndex + 1, locatorIndex);
     }
 
@@ -158,7 +159,7 @@ public final class ResourceIdentifier {
             return false;
         }
         ResourceIdentifier other = (ResourceIdentifier) obj;
-        return Objects.equals(resourceIdentifier, other.resourceIdentifier);
+        return resourceIdentifier.equals(other.resourceIdentifier);
     }
 
     /**

--- a/src/main/java/com/palantir/ri/ResourceIdentifier.java
+++ b/src/main/java/com/palantir/ri/ResourceIdentifier.java
@@ -59,18 +59,25 @@ public final class ResourceIdentifier {
             RID_CLASS + "\\." + SERVICE_REGEX + "\\." + INSTANCE_REGEX + "\\."
             + TYPE_REGEX + "\\." + LOCATOR_REGEX);
 
-    private final String service;
-    private final String instance;
-    private final String type;
-    private final String locator;
     private final String resourceIdentifier;
+    private final int serviceIndex;
+    private final int instanceIndex;
+    private final int typeIndex;
+    private final int locatorIndex;
 
     private ResourceIdentifier(String service, String instance, String type, String locator) {
-        this.service = service;
-        this.instance = instance == null ? "" : instance;
-        this.type = type;
-        this.locator = locator;
-        resourceIdentifier = toString();
+        String safeInstnace = instance == null ? "" : instance;
+        resourceIdentifier = RID_CLASS + SEPARATOR
+                + service + SEPARATOR
+                + safeInstnace + SEPARATOR
+                + type + SEPARATOR
+                + locator;
+
+        serviceIndex = RID_CLASS.length() + SEPARATOR.length() + service.length();
+        instanceIndex = serviceIndex + SEPARATOR.length() + safeInstnace.length();
+        typeIndex = instanceIndex + SEPARATOR.length() + type.length();
+        locatorIndex = typeIndex + SEPARATOR.length() + locator.length();
+
     }
 
     /**
@@ -79,7 +86,7 @@ public final class ResourceIdentifier {
      * @return the service component from this identifier
      */
     public String getService() {
-        return service;
+        return resourceIdentifier.substring(RID_CLASS.length() + SEPARATOR.length(), serviceIndex);
     }
 
     /**
@@ -88,7 +95,7 @@ public final class ResourceIdentifier {
      * @return the instance component from this identifier
      */
     public String getInstance() {
-        return instance;
+        return resourceIdentifier.substring(serviceIndex + 1, instanceIndex);
     }
 
     /**
@@ -97,7 +104,7 @@ public final class ResourceIdentifier {
      * @return the type component from this identifier
      */
     public String getType() {
-        return type;
+        return resourceIdentifier.substring(instanceIndex + 1, typeIndex);
     }
 
     /**
@@ -106,12 +113,12 @@ public final class ResourceIdentifier {
      * @return the locator component from this identifier
      */
     public String getLocator() {
-        return locator;
+        return resourceIdentifier.substring(typeIndex + 1, locatorIndex);
     }
 
     /**
      * Returns a string representation of this ResourceIdentifier. The string representation
-     * follows the format specification using the "ri" header followed by the 5 components
+     * follows the format specification using the "ri" header followed by the 4 components
      * separated by periods.
      *
      * @return a string representation of this identifier
@@ -119,18 +126,13 @@ public final class ResourceIdentifier {
     @Override
     @JsonValue
     public String toString() {
-        StringBuilder builder = new StringBuilder(RID_CLASS).append(SEPARATOR)
-                .append(service).append(SEPARATOR)
-                .append(instance).append(SEPARATOR)
-                .append(type).append(SEPARATOR)
-                .append(locator);
-        return builder.toString();
+        return resourceIdentifier;
     }
 
     /**
      * Returns the hash code value for identifier.  The hash code
      * is calculated using the Java {@link Objects#hash(Object...)} method
-     * over each of the 5 components.
+     * over each of the 4 components.
      *
      * @return the hash code value for this identifier
      */
@@ -142,7 +144,7 @@ public final class ResourceIdentifier {
     /**
      * Compares the specified object with this identifier for equality.  Returns
      * {@code true} if and only if the specified object is also a resource identifier and
-     * contain exactly the same values for all 5 components.
+     * contain exactly the same values for all 4 components.
      *
      * @param obj the object to be compared for equality with this identifier
      * @return {@code true} if the specified object is equal to this identifier, {@code false} otherwise
@@ -156,10 +158,10 @@ public final class ResourceIdentifier {
             return false;
         }
         ResourceIdentifier other = (ResourceIdentifier) obj;
-        return Objects.equals(service, other.service)
-                && Objects.equals(instance, other.instance)
-                && Objects.equals(type, other.type)
-                && Objects.equals(locator, other.locator);
+        return Objects.equals(getService(), other.getService())
+                && Objects.equals(getInstance(), other.getInstance())
+                && Objects.equals(getType(), other.getType())
+                && Objects.equals(getLocator(), other.getLocator());
     }
 
     /**
@@ -250,7 +252,7 @@ public final class ResourceIdentifier {
 
 
     /**
-     * Generates a new resource identifier object from each of the 5 input components. Each component must
+     * Generates a new resource identifier object from each of the 4 input components. Each component must
      * satisfy the requirements as defined by the specification.
      *
      * @param service input representing the service component


### PR DESCRIPTION
Hashing resource identifier is expensive due to allocating a 4 index array for hash calculation.  Use the concat'd string hash code instead which caches.  Also only stores the single toString string and returns the sub-components from the main resource identifier string.