### PR TITLE
Constructing a ResourceIdentifier no longer allocates 5 strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,54 @@
-# Gradle
-*.class
-*.jar
-.gradle
-build/
-
 # Eclipse
+*.class
+.project
+.gradle
 .classpath
 .checkstyle
-.factorypath
-.project
 .settings
-bin/
-generated/
+.node
+/build/
+*/build/
+examples/*/build/
+extras/*/build/
+bin
+.factorypath
 
-# Idea
+# SLSv2
+!*/service/bin
+**/var/log
+**/var/data
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Windows git artifact
+fileeditor
+
+# Mac specific files
+.DS_Store
+
+# IntelliJ
 *.iml
 *.ipr
 *.iws
 .idea/
 out/
+
+# Eclipse/IntelliJ APT
 generated_src/
+generated_testSrc/
+generated/
 
-# Codegen
-.generated
+# Blueprint theme
+__init__.pyc
 
-# Mac
-.DS_Store
+# Editor files
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -1,54 +1,30 @@
-# Eclipse
+# Gradle
 *.class
-.project
+*.jar
 .gradle
+build/
+
+# Eclipse
 .classpath
 .checkstyle
-.settings
-.node
-/build/
-*/build/
-examples/*/build/
-extras/*/build/
-bin
 .factorypath
+.project
+.settings
+bin/
+generated/
 
-# SLSv2
-!*/service/bin
-**/var/log
-**/var/data
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.ear
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-
-# Windows git artifact
-fileeditor
-
-# Mac specific files
-.DS_Store
-
-# IntelliJ
+# Idea
 *.iml
 *.ipr
 *.iws
 .idea/
 out/
-
-# Eclipse/IntelliJ APT
 generated_src/
 generated_testSrc/
 generated/
 
-# Blueprint theme
-__init__.pyc
+# Codegen
+.generated
 
-# Editor files
-*~
+# Mac
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,6 @@ dependencies {
 }
 
 jmh {
-    // Use profilers to collect additional data. Supported profilers:
-    // [cl, comp, gc, stack, perf, perfnorm, perfasm, xperf, xperfasm, hs_cl, hs_comp, hs_gc, hs_rt, hs_thr]
     profilers = ['gc']
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 
     annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
-    compileOnly 'org.openjdk.jmh:jmh-generator-annprocess'
+    compileOnly 'org.openjdk.jmh:jmh-core'
     jmh 'org.openjdk.jmh:jmh-core'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath 'com.palantir.baseline:gradle-baseline-java:3.92.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:1.28.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.3'
+        classpath 'gradle.plugin.org.inferred:gradle-processors:3.3.0'
         classpath 'me.champeau.jmh:jmh-gradle-plugin:0.6.5'
     }
 }
@@ -24,6 +25,7 @@ apply plugin: 'java-library'
 apply plugin: 'com.palantir.baseline'
 apply plugin: 'com.palantir.git-version'
 apply plugin: 'com.palantir.consistent-versions'
+apply plugin: 'org.inferred.processors'
 apply plugin: 'me.champeau.jmh'
 
 group 'com.palantir.ri'

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath 'com.palantir.baseline:gradle-baseline-java:3.92.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:1.28.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.3'
+        classpath 'me.champeau.jmh:jmh-gradle-plugin:0.6.5'
     }
 }
 allprojects {
@@ -23,6 +24,7 @@ apply plugin: 'java-library'
 apply plugin: 'com.palantir.baseline'
 apply plugin: 'com.palantir.git-version'
 apply plugin: 'com.palantir.consistent-versions'
+apply plugin: 'me.champeau.jmh'
 
 group 'com.palantir.ri'
 version gitVersion()
@@ -41,4 +43,20 @@ dependencies {
 
     testImplementation 'junit:junit'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
+    compileOnly 'org.openjdk.jmh:jmh-generator-annprocess'
+    jmh 'org.openjdk.jmh:jmh-core'
+    // jmh 'org.apache.logging.log4j:log4j-slf4j-impl'
+}
+
+jmh {
+    // Use profilers to collect additional data. Supported profilers:
+    // [cl, comp, gc, stack, perf, perfnorm, perfasm, xperf, xperfasm, hs_cl, hs_comp, hs_gc, hs_rt, hs_thr]
+    profilers = ['gc']
+}
+
+tasks.jmhCompileGeneratedClasses {
+    options.annotationProcessorPath = configurations.errorprone
+    options.errorprone.enabled = false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
     compileOnly 'org.openjdk.jmh:jmh-generator-annprocess'
     jmh 'org.openjdk.jmh:jmh-core'
-    // jmh 'org.apache.logging.log4j:log4j-slf4j-impl'
 }
 
 jmh {

--- a/changelog/@unreleased/pr-121.v2.yml
+++ b/changelog/@unreleased/pr-121.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Deserializing a ResourceIdentifier now causes zero heap-allocated strings
+    (previously it allocated 5).
+  links:
+  - https://github.com/palantir/resource-identifier/pull/121

--- a/src/jmh/java/com/palantir/ri/ResourceIdentifierBenchmark.java
+++ b/src/jmh/java/com/palantir/ri/ResourceIdentifierBenchmark.java
@@ -71,7 +71,7 @@ public class ResourceIdentifierBenchmark {
                 .threads(4)
                 .warmupIterations(3)
                 .warmupTime(TimeValue.seconds(3))
-                .measurementIterations(3)
+                .measurementIterations(4)
                 .measurementTime(TimeValue.seconds(3))
                 .build();
         new Runner(opt).run();

--- a/src/jmh/java/com/palantir/ri/ResourceIdentifierBenchmark.java
+++ b/src/jmh/java/com/palantir/ri/ResourceIdentifierBenchmark.java
@@ -1,0 +1,79 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.ri;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(4)
+@SuppressWarnings({"checkstyle:hideutilityclassconstructor", "VisibilityModifier", "DesignForExtension"})
+public class ResourceIdentifierBenchmark {
+
+    public enum Input {
+        NO_INSTANCE("ri.my-service..environment.8c51aa27-32f6-4d25-a3a5-966196e57be3"),
+        UUID("ri.apollo.main.installation.8c51aa27-32f6-4d25-a3a5-966196e57be3");
+
+        private final String string;
+
+        Input(String string) {
+            this.string = string;
+        }
+    }
+
+    @Param
+    Input input;
+
+    @Benchmark
+    public ResourceIdentifier fromString() {
+        return ResourceIdentifier.of(input.string);
+    }
+
+    public static void main(String[] _args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(ResourceIdentifierBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .forks(1)
+                .threads(4)
+                .warmupIterations(3)
+                .warmupTime(TimeValue.seconds(3))
+                .measurementIterations(3)
+                .measurementTime(TimeValue.seconds(3))
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/src/main/java/com/palantir/ri/ResourceIdentifier.java
+++ b/src/main/java/com/palantir/ri/ResourceIdentifier.java
@@ -265,12 +265,11 @@ public final class ResourceIdentifier {
         checkTypeIsValid(type);
         checkLocatorIsValid(locator);
 
-        String safeInstance = instance == null ? "" : instance;
         String resourceIdentifier =
-                RID_CLASS + SEPARATOR + service + SEPARATOR + safeInstance + SEPARATOR + type + SEPARATOR + locator;
+                RID_CLASS + SEPARATOR + service + SEPARATOR + instance + SEPARATOR + type + SEPARATOR + locator;
 
         int serviceIndex = RID_CLASS.length() + SEPARATOR.length() + service.length();
-        int instanceIndex = serviceIndex + SEPARATOR.length() + safeInstance.length();
+        int instanceIndex = serviceIndex + SEPARATOR.length() + instance.length();
         int typeIndex = instanceIndex + SEPARATOR.length() + type.length();
         int locatorIndex = typeIndex + SEPARATOR.length() + locator.length();
         return new ResourceIdentifier(resourceIdentifier, serviceIndex, instanceIndex, typeIndex, locatorIndex);

--- a/versions.lock
+++ b/versions.lock
@@ -2,8 +2,7 @@
 com.fasterxml.jackson.core:jackson-annotations:2.11.3 (2 constraints: bf170e71)
 net.sf.jopt-simple:jopt-simple:4.6 (1 constraints: 610a91b7)
 org.apache.commons:commons-math3:3.2 (1 constraints: 5c0a8ab7)
-org.openjdk.jmh:jmh-core:1.32 (1 constraints: 1411a7be)
-org.openjdk.jmh:jmh-generator-annprocess:1.32 (1 constraints: da04f730)
+org.openjdk.jmh:jmh-core:1.32 (1 constraints: da04f730)
 
 [Test dependencies]
 com.fasterxml.jackson.core:jackson-core:2.11.3 (1 constraints: 87123221)

--- a/versions.lock
+++ b/versions.lock
@@ -1,5 +1,9 @@
 # Run ./gradlew --write-locks to regenerate this file
 com.fasterxml.jackson.core:jackson-annotations:2.11.3 (2 constraints: bf170e71)
+net.sf.jopt-simple:jopt-simple:4.6 (1 constraints: 610a91b7)
+org.apache.commons:commons-math3:3.2 (1 constraints: 5c0a8ab7)
+org.openjdk.jmh:jmh-core:1.32 (1 constraints: 1411a7be)
+org.openjdk.jmh:jmh-generator-annprocess:1.32 (1 constraints: da04f730)
 
 [Test dependencies]
 com.fasterxml.jackson.core:jackson-core:2.11.3 (1 constraints: 87123221)

--- a/versions.props
+++ b/versions.props
@@ -1,2 +1,3 @@
 com.fasterxml.jackson.core:* = 2.11.3
 junit:junit = 4.13.2
+org.openjdk.jmh:* = 1.32


### PR DESCRIPTION
## Before this PR (544 bytes/op)

Deserializing a ResourceIdentifier from JSON involves running a regex on the entire thing, then pulling out all the matches into 4 separate strings (which allocates on the heap) and then immediately joining them back together to allocate a fifth string which was equivalent to the original string that we read from JSON.

This convoluted splitting and then re-joining just creates work to keep the GC algorithm warm, and is actually responsible for a surprising amount of allocation (even if it gets GC'd by the new collector super quickly).

![image](https://user-images.githubusercontent.com/3473798/122286797-26958600-cee8-11eb-9119-894698e37f6f.png)

```
Benchmark                                                                    (input)  Mode  Cnt     Score      Error   Units
ResourceIdentifierBenchmark.fromString                                   NO_INSTANCE  avgt    3  1117.971 ± 7036.423   ns/op
ResourceIdentifierBenchmark.fromString:·gc.alloc.rate                    NO_INSTANCE  avgt    3  1703.296 ± 8968.591  MB/sec
ResourceIdentifierBenchmark.fromString:·gc.alloc.rate.norm               NO_INSTANCE  avgt    3   544.039 ±    0.019    B/op
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Eden_Space           NO_INSTANCE  avgt    3  1715.801 ± 8858.257  MB/sec
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Eden_Space.norm      NO_INSTANCE  avgt    3   548.811 ±  201.537    B/op
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Survivor_Space       NO_INSTANCE  avgt    3     0.006 ±    0.097  MB/sec
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Survivor_Space.norm  NO_INSTANCE  avgt    3     0.002 ±    0.023    B/op
ResourceIdentifierBenchmark.fromString:·gc.count                         NO_INSTANCE  avgt    3    49.000             counts
ResourceIdentifierBenchmark.fromString:·gc.time                          NO_INSTANCE  avgt    3    31.000                 ms
ResourceIdentifierBenchmark.fromString                                          UUID  avgt    3   856.617 ±  139.048   ns/op
ResourceIdentifierBenchmark.fromString:·gc.alloc.rate                           UUID  avgt    3  2227.241 ±  356.649  MB/sec
ResourceIdentifierBenchmark.fromString:·gc.alloc.rate.norm                      UUID  avgt    3   584.040 ±    0.035    B/op
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Eden_Space                  UUID  avgt    3  2238.919 ± 1109.428  MB/sec
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Eden_Space.norm             UUID  avgt    3   587.227 ±  386.892    B/op
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Survivor_Space              UUID  avgt    3     0.007 ±    0.032  MB/sec
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Survivor_Space.norm         UUID  avgt    3     0.002 ±    0.008    B/op
ResourceIdentifierBenchmark.fromString:·gc.count                                UUID  avgt    3    64.000             counts
ResourceIdentifierBenchmark.fromString:·gc.time                                 UUID  avgt    3    37.000                 ms
```


## After this PR (248 bytes/op)

==COMMIT_MSG==
Deserializing a ResourceIdentifier now causes zero heap-allocated strings (previously it allocated 5).
==COMMIT_MSG==


```

Benchmark                                                                    (input)  Mode  Cnt     Score      Error   Units
ResourceIdentifierBenchmark.fromString                                   NO_INSTANCE  avgt    3   694.585 ±  592.517   ns/op
ResourceIdentifierBenchmark.fromString:·gc.alloc.rate                    NO_INSTANCE  avgt    3  1167.447 ± 1033.632  MB/sec
ResourceIdentifierBenchmark.fromString:·gc.alloc.rate.norm               NO_INSTANCE  avgt    3   248.022 ±    0.005    B/op
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Eden_Space           NO_INSTANCE  avgt    3  1196.048 ± 1620.917  MB/sec
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Eden_Space.norm      NO_INSTANCE  avgt    3   253.903 ±  138.877    B/op
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Survivor_Space       NO_INSTANCE  avgt    3     0.004 ±    0.012  MB/sec
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Survivor_Space.norm  NO_INSTANCE  avgt    3     0.001 ±    0.002    B/op
ResourceIdentifierBenchmark.fromString:·gc.count                         NO_INSTANCE  avgt    3    42.000             counts
ResourceIdentifierBenchmark.fromString:·gc.time                          NO_INSTANCE  avgt    3    24.000                 ms
ResourceIdentifierBenchmark.fromString                                          UUID  avgt    3   825.575 ±  332.685   ns/op
ResourceIdentifierBenchmark.fromString:·gc.alloc.rate                           UUID  avgt    3   982.036 ±  395.425  MB/sec
ResourceIdentifierBenchmark.fromString:·gc.alloc.rate.norm                      UUID  avgt    3   248.022 ±    0.010    B/op
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Eden_Space                  UUID  avgt    3   998.716 ±  911.556  MB/sec
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Eden_Space.norm             UUID  avgt    3   252.394 ±  287.709    B/op
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Survivor_Space              UUID  avgt    3     0.004 ±    0.028  MB/sec
ResourceIdentifierBenchmark.fromString:·gc.churn.G1_Survivor_Space.norm         UUID  avgt    3     0.001 ±    0.007    B/op
ResourceIdentifierBenchmark.fromString:·gc.count                                UUID  avgt    3    35.000             counts
ResourceIdentifierBenchmark.fromString:·gc.time                                 UUID  avgt    3    21.000                 ms
```