### PR TITLE
Add rid factory

### DIFF
--- a/src/main/java/com/palantir/ri/ResourceIdentifier.java
+++ b/src/main/java/com/palantir/ri/ResourceIdentifier.java
@@ -265,14 +265,7 @@ public final class ResourceIdentifier {
         checkTypeIsValid(type);
         checkLocatorIsValid(locator);
 
-        String resourceIdentifier =
-                RID_CLASS + SEPARATOR + service + SEPARATOR + instance + SEPARATOR + type + SEPARATOR + locator;
-
-        int serviceIndex = RID_CLASS.length() + SEPARATOR.length() + service.length();
-        int instanceIndex = serviceIndex + SEPARATOR.length() + instance.length();
-        int typeIndex = instanceIndex + SEPARATOR.length() + type.length();
-        int locatorIndex = typeIndex + SEPARATOR.length() + locator.length();
-        return new ResourceIdentifier(resourceIdentifier, serviceIndex, instanceIndex, typeIndex, locatorIndex);
+        return safeCreate(service, instance, type, locator);
     }
 
     /**
@@ -295,6 +288,60 @@ public final class ResourceIdentifier {
             builder.append(SEPARATOR).append(component);
         }
         return of(service, instance, type, builder.toString());
+    }
+
+    public static Factory factory() {
+        return new Factory();
+    }
+
+    public static final class Factory {
+        private String service;
+        private String instance;
+        private String type;
+
+        public Factory service(String value) {
+            checkServiceIsValid(value);
+            this.service = value;
+            return this;
+        }
+
+        public Factory instance(String value) {
+            checkInstanceIsValid(value);
+            this.instance = value;
+            return this;
+        }
+
+        public Factory type(String value) {
+            checkTypeIsValid(value);
+            this.type = value;
+            return this;
+        }
+
+        public ResourceIdentifier create(String locator) {
+            checkLocatorIsValid(locator);
+            if (service == null) {
+                throw new NullPointerException("Missing service");
+            }
+            if (instance == null) {
+                throw new NullPointerException("Missing instance");
+            }
+            if (type == null) {
+                throw new NullPointerException("Missing type");
+            }
+
+            return safeCreate(service, instance, type, locator);
+        }
+    }
+
+    private static ResourceIdentifier safeCreate(String service, String instance, String type, String locator) {
+        String resourceIdentifier =
+                RID_CLASS + SEPARATOR + service + SEPARATOR + instance + SEPARATOR + type + SEPARATOR + locator;
+
+        int serviceIndex = RID_CLASS.length() + SEPARATOR.length() + service.length();
+        int instanceIndex = serviceIndex + SEPARATOR.length() + instance.length();
+        int typeIndex = instanceIndex + SEPARATOR.length() + type.length();
+        int locatorIndex = typeIndex + SEPARATOR.length() + locator.length();
+        return new ResourceIdentifier(resourceIdentifier, serviceIndex, instanceIndex, typeIndex, locatorIndex);
     }
 
     private static void checkServiceIsValid(String service) {

--- a/src/test/java/com/palantir/ri/ResourceIdentifierFactoryTest.java
+++ b/src/test/java/com/palantir/ri/ResourceIdentifierFactoryTest.java
@@ -19,6 +19,7 @@ package com.palantir.ri;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.palantir.ri.ResourceIdentifier.Factory;
 import org.junit.jupiter.api.Test;
 
 public class ResourceIdentifierFactoryTest {
@@ -50,13 +51,10 @@ public class ResourceIdentifierFactoryTest {
     }
 
     @Test
-    void testValidRid() {
-        assertEquals(
-                ResourceIdentifier.factory()
-                        .service("s")
-                        .instance("i")
-                        .type("t")
-                        .create("l"),
-                ResourceIdentifier.of("ri.s.i.t.l"));
+    void testValidRids() {
+        Factory factory =
+                ResourceIdentifier.factory().service("s").instance("i").type("t");
+        assertEquals(factory.create("l1"), ResourceIdentifier.of("ri.s.i.t.l1"));
+        assertEquals(factory.create("l2"), ResourceIdentifier.of("ri.s.i.t.l2"));
     }
 }

--- a/src/test/java/com/palantir/ri/ResourceIdentifierFactoryTest.java
+++ b/src/test/java/com/palantir/ri/ResourceIdentifierFactoryTest.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.ri;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class ResourceIdentifierFactoryTest {
+    @Test
+    void testConstructionErrorMessage() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> ResourceIdentifier.factory()
+                .service("*"));
+        assertEquals(ex.getMessage(), "Illegal service format: *");
+        ex = assertThrows(IllegalArgumentException.class, () -> ResourceIdentifier.factory()
+                .instance("*"));
+        assertEquals(ex.getMessage(), "Illegal instance format: *");
+        ex = assertThrows(IllegalArgumentException.class, () -> ResourceIdentifier.factory()
+                .type("*"));
+        assertEquals(ex.getMessage(), "Illegal type format: *");
+        ex = assertThrows(IllegalArgumentException.class, () -> ResourceIdentifier.factory()
+                .create("*"));
+        assertEquals(ex.getMessage(), "Illegal locator format: *");
+    }
+
+    @Test
+    void testMissingType() {
+        assertThrows(
+                NullPointerException.class,
+                () -> ResourceIdentifier.factory()
+                        .service("service")
+                        .instance("instance")
+                        .create("locator"),
+                "Missing type");
+    }
+
+    @Test
+    void testValidRid() {
+        assertEquals(
+                ResourceIdentifier.factory()
+                        .service("s")
+                        .instance("i")
+                        .type("t")
+                        .create("l"),
+                ResourceIdentifier.of("ri.s.i.t.l"));
+    }
+}


### PR DESCRIPTION
In our f-c service, we are creating many RIDs, where they often share the same service, instance and type. 
We took a look at some JFRs of our busiest nodes, and found we are allocating many int arrays and Matchers in order to verify the validity of the same parts of the RID (as part of `check*IsValid` -> `Matcher` creation)

<img width="1134" alt="intarray" src="https://user-images.githubusercontent.com/87756476/126481584-a6d9e3ea-b664-47bd-a170-0928a71b2844.png">

<img width="1131" alt="matcher" src="https://user-images.githubusercontent.com/87756476/126481593-9ff55fbd-ea90-4aad-96c6-5ad2b95a4506.png">

