### PR TITLE
Require java 11 (up from java 8)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = 1.8
+sourceCompatibility = 11
 
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-annotations'

--- a/changelog/@unreleased/pr-148.v2.yml
+++ b/changelog/@unreleased/pr-148.v2.yml
@@ -1,0 +1,7 @@
+type: break
+break:
+  description: Require java 11 (up from java 8) matching our other libraries, and
+    allowing the string-heavy resource-identifier implementation to take advantage
+    of jep280 improvements to string concatenation.
+  links:
+  - https://github.com/palantir/resource-identifier/pull/148


### PR DESCRIPTION
This matches our other libraries, and allows string-heavy resource-identifier implementations to take advantage of jep280 improvements to string concatenation.