### PR TITLE
ResourceIdentifier factories require safe inputs for non-locator elements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ repositories {
 
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
+    implementation 'com.palantir.safe-logging:safe-logging'
 
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation 'net.jqwik:jqwik'

--- a/changelog/@unreleased/pr-292.v2.yml
+++ b/changelog/@unreleased/pr-292.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: ResourceIdentifier factories require safe inputs for non-locator elements
+  links:
+  - https://github.com/palantir/resource-identifier/pull/292

--- a/src/main/java/com/palantir/ri/ResourceIdentifier.java
+++ b/src/main/java/com/palantir/ri/ResourceIdentifier.java
@@ -18,6 +18,7 @@ package com.palantir.ri;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Safe;
 import java.util.Objects;
 
 /**
@@ -282,7 +283,8 @@ public final class ResourceIdentifier {
      *
      * @throws IllegalArgumentException if any of the inputs do not satisfy the resource identifier specification
      */
-    public static ResourceIdentifier of(String service, String instance, String type, String locator) {
+    public static ResourceIdentifier of(
+            @Safe String service, @Safe String instance, @Safe String type, String locator) {
         return of((CharSequence) service, instance, type, locator);
     }
 
@@ -300,7 +302,11 @@ public final class ResourceIdentifier {
      * @throws IllegalArgumentException if any of the inputs do not satisfy the resource identifier specification
      */
     public static ResourceIdentifier of(
-            String service, String instance, String type, String firstLocatorComponent, String... locatorComponents) {
+            @Safe String service,
+            @Safe String instance,
+            @Safe String type,
+            String firstLocatorComponent,
+            String... locatorComponents) {
         int locatorLength = firstLocatorComponent.length() + locatorComponents.length;
         for (String component : locatorComponents) {
             locatorLength += component.length();
@@ -316,7 +322,7 @@ public final class ResourceIdentifier {
     }
 
     private static ResourceIdentifier of(
-            CharSequence service, CharSequence instance, CharSequence type, CharSequence locator) {
+            @Safe CharSequence service, @Safe CharSequence instance, @Safe CharSequence type, CharSequence locator) {
         checkServiceIsValid(service);
         checkInstanceIsValid(instance);
         checkTypeIsValid(type);

--- a/versions.lock
+++ b/versions.lock
@@ -1,5 +1,6 @@
 # Run ./gradlew --write-locks to regenerate this file
 com.fasterxml.jackson.core:jackson-annotations:2.13.2 (2 constraints: c1174d71)
+com.palantir.safe-logging:safe-logging:1.26.0 (1 constraints: 3b053f3b)
 
 [Test dependencies]
 com.fasterxml.jackson.core:jackson-core:2.13.2 (1 constraints: 88123721)

--- a/versions.props
+++ b/versions.props
@@ -1,5 +1,6 @@
 com.fasterxml.jackson.core:* = 2.13.2
 com.fasterxml.jackson.core:jackson-databind = 2.13.2.1
+com.palantir.safe-logging:* = 1.26.0
 net.jqwik:* = 1.6.5
 org.junit.jupiter:* = 5.8.2
 org.openjdk.jmh:* = 1.35


### PR DESCRIPTION
The service, instance, and type fields must be safe. Note that
this PR does _not_ add `@Safe` annotations on the getters yet in
order to validate safe inputs are provided.