### PR TITLE
Benchmark and improve ResourceIdentifier#equals

### DIFF
--- a/src/jmh/java/com/palantir/ri/ResourceIdentifierHashEqualsBenchmark.java
+++ b/src/jmh/java/com/palantir/ri/ResourceIdentifierHashEqualsBenchmark.java
@@ -1,0 +1,78 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.ri;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(4)
+@SuppressWarnings({"checkstyle:hideutilityclassconstructor", "VisibilityModifier", "DesignForExtension"})
+public class ResourceIdentifierHashEqualsBenchmark {
+
+    private static final ResourceIdentifier rid1 =
+            ResourceIdentifier.of("ri.service.instance.type.8c51aa27-32f6-4d25-a3a5-966196e57be1");
+    private static final ResourceIdentifier rid2 =
+            ResourceIdentifier.of("ri.service.instance.type.8c51aa27-32f6-4d25-a3a5-966196e57be2");
+    private static final ResourceIdentifier rid3 = ResourceIdentifier.of(rid1.toString());
+
+    @Benchmark
+    @OperationsPerInvocation(3)
+    public int hash() {
+        return rid1.hashCode() + rid2.hashCode() + rid3.hashCode();
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(2)
+    public boolean equals() {
+        return rid1.equals(rid3) && rid1.equals(rid2);
+    }
+
+    public static void main(String[] _args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(ResourceIdentifierHashEqualsBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .forks(1)
+                .threads(4)
+                .warmupIterations(3)
+                .warmupTime(TimeValue.seconds(3))
+                .measurementIterations(4)
+                .measurementTime(TimeValue.seconds(3))
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/src/main/java/com/palantir/ri/ResourceIdentifier.java
+++ b/src/main/java/com/palantir/ri/ResourceIdentifier.java
@@ -140,7 +140,7 @@ public final class ResourceIdentifier {
             return false;
         }
         ResourceIdentifier other = (ResourceIdentifier) obj;
-        return resourceIdentifier.equals(other.resourceIdentifier);
+        return this.hashCode() == other.hashCode() && resourceIdentifier.equals(other.resourceIdentifier);
     }
 
     /**

--- a/src/main/java/com/palantir/ri/ResourceIdentifier.java
+++ b/src/main/java/com/palantir/ri/ResourceIdentifier.java
@@ -19,7 +19,6 @@ package com.palantir.ri;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Safe;
-import java.util.Objects;
 
 /**
  * Defines a common format for wrapping existing unique identifiers to provide additional context. This class
@@ -112,9 +111,7 @@ public final class ResourceIdentifier {
     }
 
     /**
-     * Returns the hash code value for identifier.  The hash code
-     * is calculated using the Java {@link Objects#hash(Object...)} method
-     * over each of the 4 components.
+     * Returns the hash code value for identifier.
      *
      * @return the hash code value for this identifier
      */

--- a/src/test/java/com/palantir/ri/ResourceIdentifierTest.java
+++ b/src/test/java/com/palantir/ri/ResourceIdentifierTest.java
@@ -232,11 +232,12 @@ final class ResourceIdentifierTest {
     @Test
     void testEqualsHashCode() {
         ResourceIdentifier prevRid = null;
-        for (int i = 0; i < goodIds.size(); ++i) {
-            ResourceIdentifier curRid = ResourceIdentifier.of(goodIds.get(i));
-            ResourceIdentifier curRid2 = ResourceIdentifier.of(goodIds.get(i));
+        for (String goodId : goodIds) {
+            ResourceIdentifier curRid = ResourceIdentifier.of(goodId);
+            ResourceIdentifier curRid2 = ResourceIdentifier.of(goodId);
             assertEquals(curRid, curRid);
             assertEquals(curRid, curRid2);
+            assertEquals(curRid2, curRid);
             assertEquals(curRid.toString(), curRid2.toString());
             assertEquals(curRid.hashCode(), curRid2.hashCode());
             assertNotEquals(curRid, NotEqualsObj.INSTANCE);


### PR DESCRIPTION
## Before this PR
ResourceIdentifier#equals did not compare hashCode()

## After this PR
The `com.palantir.ri.ResourceIdentifier#equals(Object)` method is important for performance as many services rely on comparing equality of RIDs. We can improve the performance of mismatches by utilizing the memoized hashCode when comparing two non-identity-equal RIDs before doing the byte-wise/character String equals comparison.

==COMMIT_MSG==
ResourceIdentifier#equals compares hashCode() before RID string comparison
==COMMIT_MSG==

Before
======
```
Apple M1 Pro, JDK 15.0.7, OpenJDK 64-Bit Server VM, 15.0.7+4-MTS
Benchmark                                                         Mode  Cnt   Score    Error   Units
ResourceIdentifierHashEqualsBenchmark.equals                      avgt    3   2.797 ±  0.099   ns/op
ResourceIdentifierHashEqualsBenchmark.equals:·gc.alloc.rate       avgt    3   0.010 ±  0.279  MB/sec
ResourceIdentifierHashEqualsBenchmark.equals:·gc.alloc.rate.norm  avgt    3  ≈ 10⁻⁵             B/op
ResourceIdentifierHashEqualsBenchmark.equals:·gc.count            avgt    3     ≈ 0           counts
ResourceIdentifierHashEqualsBenchmark.hash                        avgt    3   0.784 ±  0.118   ns/op
ResourceIdentifierHashEqualsBenchmark.hash:·gc.alloc.rate         avgt    3   0.006 ±  0.140  MB/sec
ResourceIdentifierHashEqualsBenchmark.hash:·gc.alloc.rate.norm    avgt    3  ≈ 10⁻⁶             B/op
ResourceIdentifierHashEqualsBenchmark.hash:·gc.count              avgt    3     ≈ 0           counts
```
```
Apple M1 Pro, JDK 17.0.3, OpenJDK 64-Bit Server VM, 17.0.3+7-LTS
Benchmark                                                         Mode  Cnt   Score    Error   Units
ResourceIdentifierHashEqualsBenchmark.equals                      avgt    3   2.126 ±  2.926   ns/op
ResourceIdentifierHashEqualsBenchmark.equals:·gc.alloc.rate       avgt    3   0.003 ±  0.071  MB/sec
ResourceIdentifierHashEqualsBenchmark.equals:·gc.alloc.rate.norm  avgt    3  ≈ 10⁻⁶             B/op
ResourceIdentifierHashEqualsBenchmark.equals:·gc.count            avgt    3     ≈ 0           counts
ResourceIdentifierHashEqualsBenchmark.hash                        avgt    3   0.359 ±  0.026   ns/op
ResourceIdentifierHashEqualsBenchmark.hash:·gc.alloc.rate         avgt    3   0.003 ±  0.070  MB/sec
ResourceIdentifierHashEqualsBenchmark.hash:·gc.alloc.rate.norm    avgt    3  ≈ 10⁻⁶             B/op
ResourceIdentifierHashEqualsBenchmark.hash:·gc.count              avgt    3     ≈ 0           counts
```

After
=====
```
Apple M1 Pro, JDK 15.0.7, OpenJDK 64-Bit Server VM, 15.0.7+4-MTS
Benchmark                                                         Mode  Cnt   Score    Error   Units
ResourceIdentifierHashEqualsBenchmark.equals                      avgt    3   1.812 ±  3.899   ns/op
ResourceIdentifierHashEqualsBenchmark.equals:·gc.alloc.rate       avgt    3   0.004 ±  0.072  MB/sec
ResourceIdentifierHashEqualsBenchmark.equals:·gc.alloc.rate.norm  avgt    3  ≈ 10⁻⁶             B/op
ResourceIdentifierHashEqualsBenchmark.equals:·gc.count            avgt    3     ≈ 0           counts
ResourceIdentifierHashEqualsBenchmark.hash                        avgt    3   0.791 ±  0.090   ns/op
ResourceIdentifierHashEqualsBenchmark.hash:·gc.alloc.rate         avgt    3   0.004 ±  0.074  MB/sec
ResourceIdentifierHashEqualsBenchmark.hash:·gc.alloc.rate.norm    avgt    3  ≈ 10⁻⁶             B/op
ResourceIdentifierHashEqualsBenchmark.hash:·gc.count              avgt    3     ≈ 0           counts
```
```
Apple M1 Pro, JDK 17.0.3, OpenJDK 64-Bit Server VM, 17.0.3+7-LTS
Benchmark                                                         Mode  Cnt   Score    Error   Units
ResourceIdentifierHashEqualsBenchmark.equals                      avgt    3   1.180 ±  0.086   ns/op
ResourceIdentifierHashEqualsBenchmark.equals:·gc.alloc.rate       avgt    3   0.004 ±  0.072  MB/sec
ResourceIdentifierHashEqualsBenchmark.equals:·gc.alloc.rate.norm  avgt    3  ≈ 10⁻⁶             B/op
ResourceIdentifierHashEqualsBenchmark.equals:·gc.count            avgt    3     ≈ 0           counts
ResourceIdentifierHashEqualsBenchmark.hash                        avgt    3   0.355 ±  0.047   ns/op
ResourceIdentifierHashEqualsBenchmark.hash:·gc.alloc.rate         avgt    3   0.004 ±  0.072  MB/sec
ResourceIdentifierHashEqualsBenchmark.hash:·gc.alloc.rate.norm    avgt    3  ≈ 10⁻⁶             B/op
ResourceIdentifierHashEqualsBenchmark.hash:·gc.count              avgt    3     ≈ 0           counts
```

## Possible downsides?
This adds an int comparison to hot equals code path, and in cases where `ResourceIdentifier` is a key for a hash structure the `hashCode()` may have just been compared and found to be equal, but in non-hash-based structures such as trees and graphs including `hashCode()` comparison in `equals()`
