### PR TITLE
Updated ResourceIdentifier equals implementation comment

### DIFF
--- a/changelog/@unreleased/pr-334.v2.yml
+++ b/changelog/@unreleased/pr-334.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Updated ResourceIdentifier equals implementation comment
+  links:
+  - https://github.com/palantir/resource-identifier/pull/334

--- a/src/main/java/com/palantir/ri/ResourceIdentifier.java
+++ b/src/main/java/com/palantir/ri/ResourceIdentifier.java
@@ -137,6 +137,9 @@ public final class ResourceIdentifier {
             return false;
         }
         ResourceIdentifier other = (ResourceIdentifier) obj;
+        // Performance note from https://github.com/palantir/resource-identifier/pull/332:
+        // We explicitly check hashCode equality first to short circuit via memoized RID String hashCode for
+        // any mismatch to avoid comparing full RID strings as RIDs are often the same length with common prefix.
         return this.hashCode() == other.hashCode() && resourceIdentifier.equals(other.resourceIdentifier);
     }
 


### PR DESCRIPTION
Updated ResourceIdentifier equals implementation comment

## Before this PR
https://github.com/palantir/resource-identifier/pull/332 didn't include clarifying comment for ResourceIdentifier equals implementation.

## After this PR
==COMMIT_MSG==
Updated ResourceIdentifier equals implementation comment
==COMMIT_MSG==

## Possible downsides?
None