### PR TITLE
Add methods to compare RID components

### DIFF
--- a/changelog/@unreleased/pr-423.v2.yml
+++ b/changelog/@unreleased/pr-423.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Provide methods to compare `ResourceIdentifier` components without
+    allocating.
+  links:
+  - https://github.com/palantir/resource-identifier/pull/423

--- a/src/main/java/com/palantir/ri/ResourceIdentifier.java
+++ b/src/main/java/com/palantir/ri/ResourceIdentifier.java
@@ -98,6 +98,67 @@ public final class ResourceIdentifier {
     }
 
     /**
+     * Compares the service component of this identifier with the given service.  Returns
+     * {@code true} if and only if the service component this identifier is equal to the given service.
+     *
+     * @param service the service to be compared for equality with the service component of this identifier
+     * @return {@code true} if the service component of this identifier is equal to the given service, {@code false}
+     * otherwise
+     */
+    public boolean hasService(String service) {
+        return substringMatches(RID_PREFIX_LENGTH, serviceIndex, service);
+    }
+
+    /**
+     * Compares the instance component of this identifier with the given instance.  Returns
+     * {@code true} if and only if the instance component this identifier is equal to the given instance.
+     *
+     * @param instance the instance to be compared for equality with the instance component of this identifier
+     * @return {@code true} if the instance component of this identifier is equal to the given instance, {@code false}
+     * otherwise
+     */
+    public boolean hasInstance(String instance) {
+        return substringMatches(serviceIndex + 1, instanceIndex, instance);
+    }
+
+    /**
+     * Compares the type component of this identifier with the given type.  Returns
+     * {@code true} if and only if the type component this identifier is equal to the given type.
+     *
+     * @param type the type to be compared for equality with the type component of this identifier
+     * @return {@code true} if the type component of this identifier is equal to the given type, {@code false}
+     * otherwise
+     */
+    public boolean hasType(String type) {
+        return substringMatches(instanceIndex + 1, typeIndex, type);
+    }
+
+    /**
+     * Compares the locator component of this identifier with the given locator.  Returns
+     * {@code true} if and only if the locator component this identifier is equal to the given locator.
+     *
+     * @param locator the locator to be compared for equality with the locator component of this identifier
+     * @return {@code true} if the locator component of this identifier is equal to the given locator, {@code false}
+     * otherwise
+     */
+    public boolean hasLocator(String locator) {
+        return substringMatches(typeIndex + 1, resourceIdentifier.length(), locator);
+    }
+
+    private boolean substringMatches(int beginIndex, int endIndex, String other) {
+        if (other == null) {
+            return false;
+        }
+
+        int length = endIndex - beginIndex;
+        if (other.length() != length) {
+            return false;
+        }
+
+        return resourceIdentifier.regionMatches(beginIndex, other, 0, length);
+    }
+
+    /**
      * Returns a string representation of this ResourceIdentifier. The string representation
      * follows the format specification using the "ri" header followed by the 4 components
      * separated by periods.

--- a/src/test/java/com/palantir/ri/ResourceIdentifierTest.java
+++ b/src/test/java/com/palantir/ri/ResourceIdentifierTest.java
@@ -160,8 +160,29 @@ final class ResourceIdentifierTest {
             String service = resourceId.getService();
             String instance = resourceId.getInstance();
             String type = resourceId.getType();
-            String oid = resourceId.getLocator();
-            assertEquals(resourceId, ResourceIdentifier.of(service, instance, type, oid), rid);
+            String locator = resourceId.getLocator();
+            assertEquals(resourceId, ResourceIdentifier.of(service, instance, type, locator), rid);
+        }
+    }
+
+    @Test
+    void testHas() {
+        for (String rid : goodIds) {
+            ResourceIdentifier resourceId = ResourceIdentifier.of(rid);
+            assertTrue(resourceId.hasService(resourceId.getService()));
+            assertTrue(resourceId.hasInstance(resourceId.getInstance()));
+            assertTrue(resourceId.hasType(resourceId.getType()));
+            assertTrue(resourceId.hasLocator(resourceId.getLocator()));
+
+            assertFalse(resourceId.hasService(null));
+            assertFalse(resourceId.hasInstance(null));
+            assertFalse(resourceId.hasType(null));
+            assertFalse(resourceId.hasLocator(null));
+
+            assertFalse(resourceId.hasService(resourceId.getService() + "a"));
+            assertFalse(resourceId.hasInstance(resourceId.getInstance() + "a"));
+            assertFalse(resourceId.hasType(resourceId.getType() + "a"));
+            assertFalse(resourceId.hasLocator(resourceId.getLocator() + "a"));
         }
     }
 


### PR DESCRIPTION
## Before this PR

Comparing locator components requires allocation.

## After this PR

Comparing locator components does not require allocation.

## Possible downsides?

Increase surface area of `ResourceIdentifier` API.

