### PR TITLE
Annotate ResourceIdentifier with @Immutable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ repositories {
 
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
+    implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.palantir.safe-logging:safe-logging'
 
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/changelog/@unreleased/pr-550.v2.yml
+++ b/changelog/@unreleased/pr-550.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Annotate `ResourceIdentifier` with `@Immutable`.
+  links:
+  - https://github.com/palantir/resource-identifier/pull/550

--- a/src/main/java/com/palantir/ri/ResourceIdentifier.java
+++ b/src/main/java/com/palantir/ri/ResourceIdentifier.java
@@ -18,6 +18,7 @@ package com.palantir.ri;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.errorprone.annotations.Immutable;
 import com.palantir.logsafe.Safe;
 
 /**
@@ -40,6 +41,7 @@ import com.palantir.logsafe.Safe;
  *      {@code [a-zA-Z0-9\-\._]+}
  * </ol>
  */
+@Immutable
 public final class ResourceIdentifier {
 
     private static final String RID_PREFIX = "ri.";

--- a/versions.lock
+++ b/versions.lock
@@ -1,5 +1,6 @@
 # Run ./gradlew writeVersionsLock to regenerate this file
 com.fasterxml.jackson.core:jackson-annotations:2.16.1 (2 constraints: c517c771)
+com.google.errorprone:error_prone_annotations:2.26.1 (1 constraints: 3d05463b)
 com.palantir.safe-logging:safe-logging:3.7.0 (1 constraints: 0c050f36)
 
 [Test dependencies]

--- a/versions.props
+++ b/versions.props
@@ -1,5 +1,6 @@
 com.fasterxml.jackson.core:* = 2.16.1
 com.fasterxml.jackson.core:jackson-databind = 2.16.1
+com.google.errorprone:error_prone_* = 2.26.1
 com.palantir.safe-logging:* = 3.7.0
 net.jqwik:* = 1.8.4
 org.junit.jupiter:* = 5.10.2


### PR DESCRIPTION
This allows `ResourceIdentifier` to be used as an enum field without triggering the Error Prone [`ImmutableEnumChecker`](https://errorprone.info/bugpattern/ImmutableEnumChecker#suppression) check.