### PR TITLE
Replace JMH plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ buildscript {
         classpath 'com.palantir.jakartapackagealignment:jakarta-package-alignment:0.6.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.81.0'
         classpath 'com.palantir.suppressible-error-prone:gradle-suppressible-error-prone:2.23.0'
-        classpath 'me.champeau.jmh:jmh-gradle-plugin:0.7.3'
     }
 }
 
@@ -35,13 +34,16 @@ apply plugin: 'com.palantir.jakarta-package-alignment'
 apply plugin: 'com.palantir.java-format'
 apply plugin: 'com.palantir.jdks'
 apply plugin: 'com.palantir.jdks.latest'
-apply plugin: 'me.champeau.jmh'
 
 group 'com.palantir.ri'
 version gitVersion()
 
 repositories {
     mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
+}
+
+sourceSets {
+    jmh
 }
 
 dependencies {
@@ -59,28 +61,24 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
 
-    testRuntimeOnly 'net.jqwik:jqwik'
+    testRuntimeOnly 'net.jqwik:jqwik-engine'
 
-    jmh 'org.openjdk.jmh:jmh-core'
-    jmh 'org.openjdk.jmh:jmh-generator-annprocess'
+    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
+
+    jmhImplementation project(':')
+    jmhImplementation 'org.openjdk.jmh:jmh-core'
 }
 
-tasks.withType(Test).configureEach {
-    dependencies {
-        testRuntimeOnly 'net.jqwik:jqwik-engine'
+tasks.register('benchmark', JavaExec) {
+    classpath = sourceSets.jmh.runtimeClasspath
+    mainClass = 'org.openjdk.jmh.Main'
+
+    if (project.hasProperty('jmh')) {
+        args(project.property('jmh').split(' '))
     }
-
-    useJUnitPlatform {
-        includeEngines 'jqwik', 'junit-jupiter'
-    }
 }
 
-tasks.named('check') { dependsOn 'javadoc', 'checkImplicitDependencies', 'checkUnusedDependencies', 'checkUnusedConstraints' }
-
-tasks.jmhCompileGeneratedClasses {
-    options.annotationProcessorPath = configurations.jmhAnnotationProcessor
-    options.errorprone.enabled = false
-}
+tasks.named('check') { dependsOn 'javadoc', 'checkUnusedDependencies', 'checkImplicitDependencies' }
 
 javaVersions {
     libraryTarget = 17

--- a/src/jmh/java/com/palantir/ri/ResourceIdentifierBenchmark.java
+++ b/src/jmh/java/com/palantir/ri/ResourceIdentifierBenchmark.java
@@ -30,7 +30,6 @@ import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-import org.openjdk.jmh.runner.options.TimeValue;
 
 @State(Scope.Benchmark)
 @Fork(1)
@@ -78,12 +77,6 @@ public class ResourceIdentifierBenchmark {
         Options opt = new OptionsBuilder()
                 .include(ResourceIdentifierBenchmark.class.getSimpleName())
                 .addProfiler(GCProfiler.class)
-                .forks(1)
-                .threads(4)
-                .warmupIterations(3)
-                .warmupTime(TimeValue.seconds(3))
-                .measurementIterations(4)
-                .measurementTime(TimeValue.seconds(3))
                 .build();
         new Runner(opt).run();
     }

--- a/src/jmh/java/com/palantir/ri/ResourceIdentifierBenchmark.java
+++ b/src/jmh/java/com/palantir/ri/ResourceIdentifierBenchmark.java
@@ -20,14 +20,12 @@ import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
-import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
@@ -35,13 +33,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
 @State(Scope.Benchmark)
-@BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
-@Threads(4)
-@SuppressWarnings({"checkstyle:hideutilityclassconstructor", "VisibilityModifier", "DesignForExtension", "NullAway"})
+@Threads(1)
+@SuppressWarnings({"DesignForExtension", "NullAway", "VisibilityModifier"})
 public class ResourceIdentifierBenchmark {
 
     public enum Input {
@@ -67,11 +61,15 @@ public class ResourceIdentifierBenchmark {
     Input input;
 
     @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public ResourceIdentifier fromString() {
         return ResourceIdentifier.of(input.string);
     }
 
     @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public ResourceIdentifier fromComponents() {
         return ResourceIdentifier.of(input.service, input.instance, input.type, input.locator);
     }

--- a/src/jmh/java/com/palantir/ri/ResourceIdentifierHashEqualsBenchmark.java
+++ b/src/jmh/java/com/palantir/ri/ResourceIdentifierHashEqualsBenchmark.java
@@ -20,28 +20,19 @@ import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
-import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
-@State(Scope.Benchmark)
-@BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
-@Threads(4)
-@SuppressWarnings({"checkstyle:hideutilityclassconstructor", "VisibilityModifier", "DesignForExtension"})
+@Threads(1)
+@SuppressWarnings({"DesignForExtension", "NullAway"})
 public class ResourceIdentifierHashEqualsBenchmark {
 
     private static final ResourceIdentifier rid1 =
@@ -51,12 +42,16 @@ public class ResourceIdentifierHashEqualsBenchmark {
     private static final ResourceIdentifier rid3 = ResourceIdentifier.of(rid1.toString());
 
     @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
     @OperationsPerInvocation(3)
     public int hash() {
         return rid1.hashCode() + rid2.hashCode() + rid3.hashCode();
     }
 
     @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
     @OperationsPerInvocation(2)
     public boolean equals() {
         return rid1.equals(rid3) && rid1.equals(rid2);

--- a/src/jmh/java/com/palantir/ri/ResourceIdentifierHashEqualsBenchmark.java
+++ b/src/jmh/java/com/palantir/ri/ResourceIdentifierHashEqualsBenchmark.java
@@ -28,7 +28,6 @@ import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-import org.openjdk.jmh.runner.options.TimeValue;
 
 @Fork(1)
 @Threads(1)
@@ -61,12 +60,6 @@ public class ResourceIdentifierHashEqualsBenchmark {
         Options opt = new OptionsBuilder()
                 .include(ResourceIdentifierHashEqualsBenchmark.class.getSimpleName())
                 .addProfiler(GCProfiler.class)
-                .forks(1)
-                .threads(4)
-                .warmupIterations(3)
-                .warmupTime(TimeValue.seconds(3))
-                .measurementIterations(4)
-                .measurementTime(TimeValue.seconds(3))
                 .build();
         new Runner(opt).run();
     }

--- a/versions.lock
+++ b/versions.lock
@@ -24,21 +24,15 @@ com.palantir.safe-logging:preconditions-assertj:3.9.0 (1 constraints: 0e051536)
 
 net.bytebuddy:byte-buddy:1.15.11 (1 constraints: 7f0bc9ea)
 
-net.jqwik:jqwik:1.9.3 (1 constraints: 0f050e36)
+net.jqwik:jqwik-api:1.9.3 (2 constraints: 510f458b)
 
-net.jqwik:jqwik-api:1.9.3 (5 constraints: 7529d3b8)
-
-net.jqwik:jqwik-engine:1.9.3 (1 constraints: a007006d)
-
-net.jqwik:jqwik-time:1.9.3 (1 constraints: a007006d)
-
-net.jqwik:jqwik-web:1.9.3 (1 constraints: a007006d)
+net.jqwik:jqwik-engine:1.9.3 (1 constraints: 0f050e36)
 
 net.sf.jopt-simple:jopt-simple:5.0.4 (1 constraints: be0ad6cc)
 
 org.apache.commons:commons-math3:3.6.1 (1 constraints: bf0adbcc)
 
-org.apiguardian:apiguardian-api:1.1.2 (11 constraints: 9293fa1e)
+org.apiguardian:apiguardian-api:1.1.2 (8 constraints: 89798c70)
 
 org.assertj:assertj-core:3.27.3 (1 constraints: 64148079)
 
@@ -56,16 +50,6 @@ org.junit.platform:junit-platform-engine:6.0.0 (3 constraints: 562da8c7)
 
 org.junit.platform:junit-platform-launcher:6.0.0 (1 constraints: 08050936)
 
-org.openjdk.jmh:jmh-core:1.37 (5 constraints: 52476be6)
+org.openjdk.jmh:jmh-core:1.37 (1 constraints: df04fc30)
 
-org.openjdk.jmh:jmh-generator-annprocess:1.37 (1 constraints: df04fc30)
-
-org.openjdk.jmh:jmh-generator-asm:1.37 (1 constraints: 2c107598)
-
-org.openjdk.jmh:jmh-generator-bytecode:1.37 (1 constraints: de04fb30)
-
-org.openjdk.jmh:jmh-generator-reflection:1.37 (2 constraints: 491e3064)
-
-org.opentest4j:opentest4j:1.3.0 (6 constraints: 7846fee1)
-
-org.ow2.asm:asm:9.0 (1 constraints: ec0d4f34)
+org.opentest4j:opentest4j:1.3.0 (4 constraints: 053455a8)


### PR DESCRIPTION
The `me.champeau.jmh` has a number of downsides and isn't really necessary for modern projects:
- It uses the bytecode generator instead of the more modern annotation processor.
- The bytecode generation task does not include the Java version as part of the cache key, so Gradle builds fail when run on older version and we attempt to unpack this result from the Gradle build cache.
- It will provision it's own JDKs that don't use the JDKs configured by our toolchain tooling.