### PR TITLE
Fix JMH configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,9 @@ repositories {
 }
 
 sourceSets {
-    jmh
+    jmh {
+        java {}
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Small correction from https://github.com/palantir/resource-identifier/pull/663.

Attempting to run benchmarks fails without this:

```
.$ ./gradlew --no-scan benchmark '-Pjmh=ResourceIdentifierBenchmark'

[Incubating] Problems report is available at: file:///Volumes/git/resource-identifier/build/reports/problems/problems-report.html

FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* Where:
Build file '/Volumes/git/resource-identifier/build.gradle' line: 68

* What went wrong:
A problem occurred evaluating root project 'resource-identifier'.
> Could not find method jmhAnnotationProcessor() for arguments [org.openjdk.jmh:jmh-generator-annprocess] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
```